### PR TITLE
UI Fix Empty Book Cover and Profile

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -161,14 +161,12 @@ const NavBar = () => {
       {/* User Section */}
       <div className="flex row gap-3 mr-14 mt-2">
         {/* Profile Picture */}
-        <Link href="/profile">
-          <Image
-            src={profilePic}
-            alt="Profile Picture"
-            style={STYLES.profilePic}
-            className="w-8 h-8 rounded-full -mt-1"
-          />
-        </Link>
+        <Image
+          src={profilePic}
+          alt="Profile Picture"
+          style={STYLES.profilePic}
+          className="w-8 h-8 rounded-full -mt-1"
+        />
 
         {/* User Menu */}
         <UserMenu name={user?.name} onSignOut={handleSignOut} />

--- a/src/lib/api/books.ts
+++ b/src/lib/api/books.ts
@@ -89,6 +89,8 @@ export const deleteBook = async (bookId: number): Promise<Book | undefined> => {
   }
 };
 
+const DEFAULT_IMAGE = 'https://drive.google.com/file/d/16AqCXCMmHGEN1kLqjaGe2DYKEQEyhIMk/view?usp=drive_link' 
+
 export const getBookCover = async (
   bookISBN: string
 ): Promise<string | undefined> => {
@@ -103,5 +105,5 @@ export const getBookCover = async (
     console.warn("Error fetching image");
   }
 
-  // return imageToAdd.src;
+  return DEFAULT_IMAGE;
 };


### PR DESCRIPTION
# Description
Fixed the profile so that it is unclickable

## Issue

## Test
Try Clicking the Profile button

## Possible Downsides or 
The empty book cover needs to be reconsidered, as a url for the book cover is still being fetched even for books that do not have a cover, thus making it impossible to determine whether a book has white rectangle for a cover or an actual cover.

