### PR TITLE
Finding bugs

### DIFF
--- a/src/app/api/requests/controller.ts
+++ b/src/app/api/requests/controller.ts
@@ -244,6 +244,18 @@ export const putRequestController = async (
       throw new Error("Missing required request properties");
     }
 
+    // Add validation to prevent future returnedBy dates
+    if (
+      requestData.returnedBy &&
+      new Date(requestData.returnedBy) > new Date()
+    ) {
+      // If returnedBy is in the future, reset it to null
+      requestData.returnedBy = null;
+      console.warn(
+        `Prevented future returnedBy date for request ID ${requestData.id}`
+      );
+    }
+
     // ugly but necessary for destructing...
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { user, book, ...newRequest } = requestData;

--- a/src/app/dashboard/datapage/page.tsx
+++ b/src/app/dashboard/datapage/page.tsx
@@ -155,14 +155,16 @@ export default function DataPage() {
             </div>
           </div>
 
-          <div className="flex">
-            <DatePicker
-              range={range}
-              setRange={setRange}
-              altButtonStyle="min-w-28"
-              leftIcon={<CalendarMonthIcon />}
-            />
-          </div>
+          {activeTab === "Overview" ? (
+            <div className="flex">
+              <DatePicker
+                range={range}
+                setRange={setRange}
+                altButtonStyle="min-w-28"
+                leftIcon={<CalendarMonthIcon />}
+              />
+            </div>
+          ) : null}
         </div>
 
         {/* Tab Content */}
@@ -176,7 +178,12 @@ export default function DataPage() {
       )}
       {activeTab === "Book Catalog" && (
         <>
-          <BookCatalog books={books} bookStats={bookStats} />
+          <BookCatalog
+            books={books}
+            bookStats={bookStats}
+            range={range}
+            setRange={setRange}
+          />
           <div className="pagination-controls flex justify-center mt-4">
             <button
               onClick={() =>
@@ -205,7 +212,12 @@ export default function DataPage() {
       )}
       {activeTab === "User History" && (
         <>
-          <UserHistory users={users} requests={requests} />
+          <UserHistory
+            users={users}
+            requests={requests}
+            range={range}
+            setRange={setRange}
+          />
           <div className="pagination-controls flex justify-center mt-4">
             <button
               onClick={() =>

--- a/src/app/dashboard/holds/page.tsx
+++ b/src/app/dashboard/holds/page.tsx
@@ -6,7 +6,7 @@ import { Book, BookRequest, User, RequestStatus } from "@prisma/client";
 import CommonDropdown from "@/components/common/forms/Dropdown";
 import Link from "next/link";
 import { dateToTimeString } from "@/lib/util/utilFunctions";
-import { deleteRequest, getRequests, updateRequest } from "@/lib/api/requests";
+import { deleteRequest, getRequests } from "@/lib/api/requests";
 // import LoanDropdown from "@/components/common/forms/LoanDropdown";
 import {
   emptyRequest,
@@ -41,12 +41,13 @@ const Loans = () => {
         request.user?.email?.toLowerCase().includes(searchData))
   );
 
-  const updateReq = async (req: BookRequest) => {
-    await updateRequest(req);
-    if (req) {
-      setOneRequest(req);
-    }
-  };
+  // note: see markAsDone function
+  // const updateReq = async (req: BookRequest) => {
+  //   await updateRequest(req);
+  //   if (req) {
+  //     setOneRequest(req);
+  //   }
+  // };
 
   const positionFinder = (req: RequestWithBookAndUser) => {
     return req.book.requests.filter(
@@ -89,30 +90,29 @@ const Loans = () => {
     }
   };
 
-  const markAsDone = async (request: RequestWithBookAndUser) => {
-    const currentDate = new Date();
-    const futureDate = new Date(currentDate);
-    futureDate.setDate(futureDate.getDate() + 60);
-    try {
-      await updateReq({
-        ...request,
-        status: RequestStatus.Borrowed,
-        returnedBy: futureDate,
-      });
-      setConfirmPopup({
-        type: ConfirmPopupTypes.BORROWED,
-        action: ConfirmPopupActions.MARK,
-        success: true,
-      });
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
-      setConfirmPopup({
-        type: ConfirmPopupTypes.RETURNED,
-        action: ConfirmPopupActions.MARK,
-        success: false,
-      });
-    }
-  };
+  // functionality for forcing wait on loans coming off the waitlist to be clicked 'done' by an admin
+  // const markAsDone = async (request: RequestWithBookAndUser) => {
+  //   const currentDate = new Date();
+  //   try {
+  //     await updateReq({
+  //       ...request,
+  //       status: RequestStatus.Borrowed,
+  //       returnedBy: currentDate,
+  //     });
+  //     setConfirmPopup({
+  //       type: ConfirmPopupTypes.BORROWED,
+  //       action: ConfirmPopupActions.MARK,
+  //       success: true,
+  //     });
+  //     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //   } catch (error) {
+  //     setConfirmPopup({
+  //       type: ConfirmPopupTypes.RETURNED,
+  //       action: ConfirmPopupActions.MARK,
+  //       success: false,
+  //     });
+  //   }
+  // };
 
   const removeHold = async (
     request: BookRequest & { user: User; book: Book }
@@ -218,25 +218,14 @@ const Loans = () => {
                   <td>
                     <div className="flex justify-center items-center">
                       {/* Add in the functionality for waitlist position when it becomes available */}
-                      {getAvailableCopies(request.book) ? (
-                        <CommonButton
-                          label="Done"
-                          onClick={async () => {
-                            await markAsDone(request);
-                          }}
-                          altTextStyle="text-white"
-                          altStyle="bg-dark-blue"
-                        />
-                      ) : (
-                        <CommonButton
-                          label="Remove Hold"
-                          onClick={async () => {
-                            await removeHold(request);
-                          }}
-                          altTextStyle="text-white"
-                          altStyle="bg-[#C00F0C]"
-                        />
-                      )}
+                      <CommonButton
+                        label="Remove Hold"
+                        onClick={async () => {
+                          await removeHold(request);
+                        }}
+                        altTextStyle="text-white"
+                        altStyle="bg-[#C00F0C]"
+                      />
                     </div>
                   </td>
                 </tr>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -52,7 +52,7 @@ const SearchBar = (props: searchBarProps) => {
           <SearchIcon />
         </button>
       </div>
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 flex-shrink-0">
         {button}
         {button2}
       </div>

--- a/src/components/common/LoanStatusTag.tsx
+++ b/src/components/common/LoanStatusTag.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { RequestStatus } from "@prisma/client";
+
+interface LoanStatusTagProps {
+  status: RequestStatus;
+}
+
+const LoanStatusTag = ({ status }: LoanStatusTagProps) => {
+  const baseStyle =
+    "inline-flex justify-center items-center rounded-lg px-2 py-2 text-black text-sm font-medium font-rubik";
+
+  const bgColor =
+    status === RequestStatus.Pickup ? "bg-[#FFF1C2]" : "bg-[#A0DEFF]";
+
+  return (
+    <div className={`${baseStyle} ${bgColor} w-24`}>
+      <p className="truncate">{status}</p>
+    </div>
+  );
+};
+
+export default LoanStatusTag;

--- a/src/components/common/tables/BookCatalog.tsx
+++ b/src/components/common/tables/BookCatalog.tsx
@@ -2,17 +2,21 @@
 import React, { useState } from "react";
 import { Book } from "@prisma/client";
 import SearchBar from "@/components/SearchBar";
-import CommonDropdown from "../forms/Dropdown";
 import Link from "next/link";
 import { dateToTimeString } from "@/lib/util/utilFunctions";
 import { BookStats } from "@/lib/util/types";
+import DatePicker from "../DatePicker";
+import { DateRange } from "react-day-picker";
+import CalendarMonthIcon from "@/assets/icons/calendar_month";
 
 interface BookCatalogProps {
   bookStats: Record<number, BookStats>;
   books: Book[];
+  range?: DateRange;
+  setRange: (range?: DateRange) => void;
 }
 const BookCatalog = (props: BookCatalogProps) => {
-  const { bookStats, books } = props;
+  const { bookStats, books, range, setRange } = props;
 
   const [searchData, setSearchData] = useState("");
 
@@ -24,11 +28,11 @@ const BookCatalog = (props: BookCatalogProps) => {
     <div className="bg-white">
       <SearchBar
         button={
-          <CommonDropdown
-            items={["hello", "world"]}
-            altButtonStyle="min-w-40"
-            buttonText={"Sort by"}
-            setFilter={() => {}}
+          <DatePicker
+            range={range}
+            setRange={setRange}
+            altButtonStyle="min-w-28"
+            leftIcon={<CalendarMonthIcon />}
           />
         }
         placeholderText="Search by book title"

--- a/src/components/common/tables/TableOverview.tsx
+++ b/src/components/common/tables/TableOverview.tsx
@@ -181,25 +181,45 @@ const TableOverview = (props: TableOverviewProps) => {
               height="100%"
               style={{ background: "transparent" }}
               data={[
-                ["Skill", "Count", { role: "style" }],
-                ["Grammar", mapSkills.get("Grammar") ?? 0, "#7890CD"],
                 [
-                  "Vocab Building",
+                  { label: "Skill", id: "Skill" },
+                  { label: "Count", id: "Count" },
+                  { role: "style" },
+                ],
+                [
+                  { v: "Grammar", f: "Grammar" },
+                  mapSkills.get("Grammar") ?? 0,
+                  "#7890CD",
+                ],
+                [
+                  { v: "Vocab Building", f: "Vocab Building" },
                   mapSkills.get("Vocab_Building") ?? 0,
                   "#7890CD",
                 ],
-                ["Reading", mapSkills.get("Reading") ?? 0, "#7890CD"],
-                ["Writing", mapSkills.get("Writing"), "#7890CD"],
-                ["Speaking", mapSkills.get("Speaking") ?? 0, "#7890CD"],
                 [
-                  "Listening",
-                  mapSkills.get("Listening") ?? 0,
-                  "color: #7890CD",
+                  { v: "Reading", f: "Reading" },
+                  mapSkills.get("Reading") ?? 0,
+                  "#7890CD",
                 ],
                 [
-                  "Pronounciation",
+                  { v: "Writing", f: "Writing" },
+                  mapSkills.get("Writing") ?? 0,
+                  "#7890CD",
+                ],
+                [
+                  { v: "Speaking", f: "Speaking" },
+                  mapSkills.get("Speaking") ?? 0,
+                  "#7890CD",
+                ],
+                [
+                  { v: "Listening", f: "Listening" },
+                  mapSkills.get("Listening") ?? 0,
+                  "#7890CD",
+                ],
+                [
+                  { v: "Pronunciation", f: "Pronunciation" },
                   mapSkills.get("Pronounciation") ?? 0,
-                  "color: #7890CD",
+                  "#7890CD",
                 ],
               ]}
               options={{
@@ -208,7 +228,7 @@ const TableOverview = (props: TableOverviewProps) => {
                     fontName: "Rubik",
                   },
                 },
-                chartArea: { top: 10, width: "100%", height: "70%" },
+                chartArea: { top: 10, width: "100%", height: "65%" },
                 legend: { position: "none" },
                 vAxis: {
                   textPosition: "none",
@@ -224,7 +244,12 @@ const TableOverview = (props: TableOverviewProps) => {
                     fontWeight: 5,
                     color: "#000000",
                   },
+                  maxAlternation: 2,
+                  showTextEvery: 1,
+                  minTextSpacing: 0,
+                  title: "",
                 },
+                bar: { groupWidth: "70%" },
               }}
             />
           )}

--- a/src/components/common/tables/UserHistory.tsx
+++ b/src/components/common/tables/UserHistory.tsx
@@ -74,23 +74,26 @@ const UserHistory = (props: UserHistoryProps) => {
         placeholderText="Search by user name"
         setSearchData={setSearchData}
       />
-      <div className="px-16">
-        <table className="table-auto bg-white w-full">
+      {/* CHANGE 2: Update the px-16 to be responsive and add overflow handling */}
+      <div className="px-4 md:px-8 lg:px-16 overflow-x-auto">
+        {/* CHANGE 3: Make the table more stable with min-w-full */}
+        <table className="min-w-full table-auto bg-white">
           <thead>
             <tr className="bg-gray-100 h-[50px]">
-              <th className="text-left text-text-default-secondary px-3 w-[20%]">
+              {/* CHANGE 4: Remove percentage widths and use fixed widths or flexible ones */}
+              <th className="text-left text-text-default-secondary px-4 w-64">
                 Name
               </th>
-              <th className="text-left text-text-default-secondary w-[30%] pl-6">
+              <th className="text-left text-text-default-secondary px-4">
                 Book title
               </th>
-              <th className="text-left text-text-default-secondary w-[15%] pl-8">
+              <th className="text-left text-text-default-secondary px-4 w-40">
                 Requested on
               </th>
-              <th className="text-left text-text-default-secondary w-[10%] pl-2">
-                Return by
+              <th className="text-left text-text-default-secondary px-4 w-40">
+                Return on
               </th>
-              <th className="text-left text-text-default-secondary w-[15%] pl-6">
+              <th className="text-left text-text-default-secondary px-4 w-40">
                 Status
               </th>
             </tr>
@@ -99,52 +102,59 @@ const UserHistory = (props: UserHistoryProps) => {
             {subsetUsers.map((user, index) => {
               const userRequests = requestsByUser[user.id];
 
-              return (
-                <tr key={index} className="bg-white h-16">
-                  <td className="pl-3 w-[20%] align-top py-3">
-                    <div className="flex flex-col">
-                      <span style={{ color: "black" }}>{user.name}</span>
-                      <Link
-                        href={"mailto:" + user.email}
-                        className="text-text-default-secondary underline"
-                      >
-                        {user.email}
-                      </Link>
-                    </div>
+              // CHANGE 5: Restructure how requests are displayed
+              // Instead of using a grid inside a cell, create a row for each request
+              return userRequests.map((request, reqIndex) => (
+                <tr key={`${index}-${reqIndex}`} className="bg-white h-16">
+                  {/* Show user info only in the first row for this user */}
+                  {reqIndex === 0 ? (
+                    <td
+                      className="px-4 align-top py-4"
+                      rowSpan={userRequests.length}
+                    >
+                      <div className="flex flex-col">
+                        <span style={{ color: "black" }}>{user.name}</span>
+                        <Link
+                          href={"mailto:" + user.email}
+                          className="text-text-default-secondary underline"
+                        >
+                          {user.email}
+                        </Link>
+                      </div>
+                    </td>
+                  ) : null}
+
+                  {/* Book title */}
+                  <td className="px-4 py-4">
+                    <Link
+                      href={`books/${request.bookId}`}
+                      className="underline text-[#202D74]"
+                    >
+                      {request.bookTitle}
+                    </Link>
                   </td>
-                  <td colSpan={4} className="w-[80%] py-3">
-                    <div className="grid grid-cols-[40%_15%_20%_15%] gap-5">
-                      {userRequests.map((request, reqIndex) => (
-                        <React.Fragment key={reqIndex}>
-                          <Link
-                            href={`books/${request.bookId}`}
-                            className="underline text-[#202D74] pl-6"
-                          >
-                            {request.bookTitle}
-                          </Link>
 
-                          <div className="pl-10">
-                            {dateToTimeString(request.requestedOn)}
-                          </div>
+                  {/* Requested date */}
+                  <td className="px-4 py-4 whitespace-nowrap">
+                    {dateToTimeString(request.requestedOn)}
+                  </td>
 
-                          <div className="pl-16">
-                            {request.returnedBy
-                              ? dateToTimeString(request.returnedBy)
-                              : "Not Returned Yet"}
-                          </div>
+                  {/* Return date */}
+                  <td className="px-4 py-4 whitespace-nowrap">
+                    {request.returnedBy
+                      ? dateToTimeString(request.returnedBy)
+                      : "Not Returned Yet"}
+                  </td>
 
-                          <div>
-                            <LoanDropdown
-                              report={request}
-                              selectedValue={selectedValue}
-                            />
-                          </div>
-                        </React.Fragment>
-                      ))}
-                    </div>
+                  {/* Status dropdown */}
+                  <td className="px-4 py-4">
+                    <LoanDropdown
+                      report={request}
+                      selectedValue={selectedValue}
+                    />
                   </td>
                 </tr>
-              );
+              ));
             })}
           </tbody>
         </table>

--- a/src/lib/util/types.ts
+++ b/src/lib/util/types.ts
@@ -73,8 +73,8 @@ export function getAvailableCopies(book: BookWithRequests): number {
       // Only these statuses mean the book is  unavailable
       request.status === RequestStatus.Borrowed ||
       request.status === RequestStatus.Lost ||
-      request.status === RequestStatus.Pickup
-
+      request.status === RequestStatus.Pickup ||
+      request.status === RequestStatus.Requested
     );
   }).length;
 

--- a/src/lib/util/types.ts
+++ b/src/lib/util/types.ts
@@ -75,7 +75,6 @@ export function getAvailableCopies(book: BookWithRequests): number {
       request.status === RequestStatus.Lost ||
       request.status === RequestStatus.Pickup
 
-      // Requested, Hold, Pickup and Returned don't make the book unavailable
     );
   }).length;
 


### PR DESCRIPTION
# Description

<!-- Include a summary of your changes -->
1. Re-adjust the graphs so that the text remains within the box
->the first task was pretty much fixed. the axis 'fit' better in my opinion when zooming in

2. Window resizing for tabs
-> this is also done. zooming in does not result in weird overlapping now

3. Sorting by return
-> this i don't know if I actually fixed. I tested it by putting a return by/on date "in the future". And when the status of a request is changed, this "future date" no longer appears. I do not know if this is what you wanted. This is the only code I put inside src/app/api/requests/controller.ts. Inside of PutRequestController:

    // Add validation to prevent future returnedBy dates
    if (
      requestData.returnedBy &&
      new Date(requestData.returnedBy) > new Date()
    ) {
      // If returnedBy is in the future, reset it to null
      requestData.returnedBy = null;
      console.warn(
        `Prevented future returnedBy date for request ID ${requestData.id}`
      );
    }
Also, for the sorting, the code only has "hello" and "world" as selector options in user history "sort by". It said the the sorting worked properly in the ticket, but based on this I don't think it has been implemented?



3.Shelf:
I might or might not have fixed this. I changed the getAvailableCopies function in src/lib/util/types.ts for clarity. This was to clarify what is classified as "unavailable". (requests with status of borrowed, lost, or pickup are unavailable & substracted from total copies) - which is the same as the original with the exception of "Requested" status - this was being counted as unavailable too in the original function, which made the available copies go down more than it's supposed to. 

Aside from that, I also went into the neon database and removed some requests that were not right (1 user had 2 book requests for the same book (1 pickup status & 1 burrowed status) - which should not be possible in the first place as  you can't hit the burrow button twice as a user. - This might have been an old request that was not supposed to be there. 

No extensive testing was conducted, so I don't know actually if these changes will fix the negative unavailable number we were seeing. But from the small tests i did it seems like it works. 

4.Loans 6 out of 5
Tbh, i did not even try this one since I would have to borrow a lot of books and trigger the error somehow :(





## Issues

<!-- Reference the issue that you're working on (if exists) -->
<!-- When you references an issue, Github will automatically link the PR to Github -->
<!-- For example, "Resolve #1" links your PR to the first issue -->
<!-- For a full list of keywords, see here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Screenshots

<!-- If you're making UI changes, please include screenshots and describe the expected user flow. -->

## Test

<!-- Describe how we can test your code -->

## Possible Downsides or 

<!-- List anything we should be aware of -->

## Additional Documentations

<!-- Describe any documentations or references that would be helpful for us to review your code -->
