### PR TITLE
No holds/loans + dashboard redesign

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,14 +32,13 @@ model Book {
   publisher   String
   releaseDate String?
   skills      BookSkills[]
-  bookType    BookType?
-  level       BookLevel?
+  bookType    BookType
+  level       BookLevel
   numPages    Int?          @default(0)
   coverURL    String        @default("placeholder")
   copies      Int           @default(0)
   isbn        String[]
   createdAt   DateTime      @default(now()) @map("created_at")
-  extraInfo   String?
   requests    BookRequest[]
 
   @@map("Books")
@@ -49,13 +48,12 @@ model BookRequest {
   id          Int           @id @default(autoincrement())
   userId      String
   bookId      Int
-  status      RequestStatus
   createdAt   DateTime
   message     String
   bookTitle   String
   requestedOn DateTime
-  returnedBy  DateTime?
-  dueDate     DateTime?
+  returnedBy  DateTime
+  status      RequestStatus
   book        Book          @relation(fields: [bookId], references: [id], onDelete: Cascade)
   user        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,13 +32,14 @@ model Book {
   publisher   String
   releaseDate DateTime?     @default(now())
   skills      BookSkills[]
-  bookType    BookType
-  level       BookLevel
+  bookType    BookType?
+  level       BookLevel?
   numPages    Int?          @default(0)
   coverURL    String        @default("placeholder")
   copies      Int           @default(0)
   isbn        String[]
   createdAt   DateTime      @default(now()) @map("created_at")
+  extraInfo   String?
   requests    BookRequest[]
 
   @@map("Books")
@@ -48,12 +49,13 @@ model BookRequest {
   id          Int           @id @default(autoincrement())
   userId      String
   bookId      Int
+  status      RequestStatus
   createdAt   DateTime
   message     String
   bookTitle   String
   requestedOn DateTime
-  returnedBy  DateTime
-  status      RequestStatus
+  returnedBy  DateTime?
+  dueDate     DateTime?
   book        Book          @relation(fields: [bookId], references: [id], onDelete: Cascade)
   user        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/src/app/dashboard/datapage/page.tsx
+++ b/src/app/dashboard/datapage/page.tsx
@@ -38,6 +38,7 @@ export default function DataPage() {
   // LOADING STATES
   const [loadingBooks, setLoadingBooks] = useState(false);
   const [loadingUsers, setLoadingUsers] = useState(false);
+  const [loadingGraphs, setLoadingGraphs] = useState(false);
 
   useEffect(() => {
     if (activeTab === "Book Catalog") {
@@ -114,6 +115,7 @@ export default function DataPage() {
   }, [range, currentUserPage, activeTab, searchData]); // Refetch users when currentUserPage or activeTab changes
 
   useEffect(() => {
+    setLoadingGraphs(true);
     const fetchData = async () => {
       try {
         const booksResult = await getAllBooks({
@@ -192,6 +194,7 @@ export default function DataPage() {
       } finally {
         setCurrentUserPage(1);
         setCurrentBookPage(1);
+        setLoadingGraphs(false);
       }
     };
     fetchData();
@@ -236,14 +239,17 @@ export default function DataPage() {
 
         {/* Tab Content */}
       </div>
-      {activeTab === "Overview" && (
-        <TableOverview
-          borrowDuration={averageDuration}
-          topThree={topThree}
-          requestCount={requestCount}
-          range={range}
-        />
-      )}
+      {activeTab === "Overview" &&
+        (loadingGraphs ? (
+          <LoadingSkeleton />
+        ) : (
+          <TableOverview
+            borrowDuration={averageDuration}
+            topThree={topThree}
+            requestCount={requestCount}
+            range={range}
+          />
+        ))}
       {activeTab === "Book Catalog" && (
         <>
           <SearchBar

--- a/src/app/dashboard/onlineResources/page.tsx
+++ b/src/app/dashboard/onlineResources/page.tsx
@@ -3,14 +3,16 @@ import React, { useEffect } from "react";
 import { useState } from "react";
 import DisplayFolder from "@/components/common/DisplayFolder";
 import { getAllSubFolders, getFolderResources } from "@/lib/api/drive";
+import LoadingSkeleton from "@/app/loading";
 
 const OnlineResourcesPage = () => {
   const [resourceFolders, setResourceFolders] = useState<
     { name: string; id: string; count: number }[]
   >([]);
-
+  const [loadingFolders, setLoadingFolders] = useState(false);
   useEffect(() => {
     const fetchSubFolders = async () => {
+      setLoadingFolders(true);
       const folders = await getAllSubFolders(
         "1K6S8q9I9Qk0O0Dikf3sME9K_sHEwXSTs"
       );
@@ -28,7 +30,7 @@ const OnlineResourcesPage = () => {
               count: response ?? 0,
             };
           })
-      );
+      ).finally(() => setLoadingFolders(false));
       setResourceFolders(folderData);
     };
 
@@ -37,30 +39,34 @@ const OnlineResourcesPage = () => {
 
   return (
     <div>
-      <div className="p-4 px-16 bg-white border-t">
-        <div className="flex flex-row text-left whitespace-normal">
-          <p className="text-sm text-slate-500 mb-6">
-            {resourceFolders.reduce((acc, cur) => {
-              return cur.count + acc;
-            }, 0)}
-            {" resources"}
-          </p>
+      {loadingFolders ? (
+        <LoadingSkeleton />
+      ) : (
+        <div className="p-4 px-16 bg-white border-t">
+          <div className="flex flex-row text-left whitespace-normal">
+            <p className="text-sm text-slate-500 mb-6">
+              {resourceFolders.reduce((acc, cur) => {
+                return cur.count + acc;
+              }, 0)}
+              {" resources"}
+            </p>
+          </div>
+          <div>
+            <ul className="grid grid-cols-2 gap-4">
+              {resourceFolders.map((folder) => {
+                if (folder.name && folder.id)
+                  return (
+                    <li key={folder.id}>
+                      <div className="p-4 border-gray-200 border bg-white shadow-md rounded-md hover:bg-blue-100 transition duration-200 mb-10">
+                        <DisplayFolder resource={folder} />
+                      </div>
+                    </li>
+                  );
+              })}
+            </ul>
+          </div>
         </div>
-        <div>
-          <ul className="grid grid-cols-2 gap-4">
-            {resourceFolders.map((folder) => {
-              if (folder.name && folder.id)
-                return (
-                  <li key={folder.id}>
-                    <div className="p-4 border-gray-200 border bg-white shadow-md rounded-md hover:bg-blue-100 transition duration-200 mb-10">
-                      <DisplayFolder resource={folder} />
-                    </div>
-                  </li>
-                );
-            })}
-          </ul>
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/app/dashboard/shelf/[id]/page.tsx
+++ b/src/app/dashboard/shelf/[id]/page.tsx
@@ -72,60 +72,69 @@ const Shelf = (props: { params: Promise<Params> }) => {
         </div>
       </div>
 
-      <div>
-        <div className="font-[family-name:var(--font-rubik)] mb-5 mt-10">
-          {" "}
-          Your loans{" "}
+      {loans.length > 0 && (
+        <div>
+          <div className="font-[family-name:var(--font-rubik)] mb-5 mt-10">
+            {" "}
+            Your loans{" "}
+          </div>
+          <ul className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {loans.map((request) => (
+              <li key={request.id} className="h-full">
+                <div className="h-full p-4 rounded-md border-2 border-[#D9D9D9]">
+                  <BookInfo
+                    book={request.book}
+                    user={user}
+                    onDelete={() => {
+                      setLoans((prevLoans) =>
+                        prevLoans.filter((r) => r.id !== request.id)
+                      );
+                      setHolds((prevHolds) =>
+                        prevHolds.filter((r) => r.id !== request.id)
+                      );
+                    }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
-        <ul className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {loans.map((request) => (
-            <li key={request.id} className="h-full">
-              <div className="h-full p-4 rounded-md border-2 border-[#D9D9D9]">
-                <BookInfo
-                  book={request.book}
-                  user={user}
-                  onDelete={() => {
-                    setLoans((prevLoans) =>
-                      prevLoans.filter((r) => r.id !== request.id)
-                    );
-                    setHolds((prevHolds) =>
-                      prevHolds.filter((r) => r.id !== request.id)
-                    );
-                  }}
-                />
-              </div>
-            </li>
-          ))}
-        </ul>
-      </div>
+      )}
 
-      <div className="pb-[100px]">
-        <div className="font-[family-name:var(--font-rubik)] mb-5 mt-10">
-          {" "}
-          Your holds{" "}
+      {holds.length > 0 && (
+        <div className="pb-[100px]">
+          <div className="font-[family-name:var(--font-rubik)] mb-5 mt-10">
+            {" "}
+            Your holds{" "}
+          </div>
+          <ul className="flex flex-wrap gap-4">
+            {holds.map((request) => (
+              <li key={request.id} className="w-1/2">
+                <div className="p-4 rounded-md border-2 border-[#D9D9D9] m-2">
+                  <BookInfo
+                    book={request.book}
+                    user={user}
+                    onDelete={() => {
+                      // Remove from loans or holds after cancel
+                      setLoans((prevLoans) =>
+                        prevLoans.filter((r) => r.id !== request.id)
+                      );
+                      setHolds((prevHolds) =>
+                        prevHolds.filter((r) => r.id !== request.id)
+                      );
+                    }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
-        <ul className="flex flex-wrap gap-4">
-          {holds.map((request) => (
-            <li key={request.id} className="w-1/2">
-              <div className="p-4 rounded-md border-2 border-[#D9D9D9] m-2">
-                <BookInfo
-                  book={request.book}
-                  user={user}
-                  onDelete={() => {
-                    // Remove from loans or holds after cancel
-                    setLoans((prevLoans) =>
-                      prevLoans.filter((r) => r.id !== request.id)
-                    );
-                    setHolds((prevHolds) =>
-                      prevHolds.filter((r) => r.id !== request.id)
-                    );
-                  }}
-                />
-              </div>
-            </li>
-          ))}
-        </ul>
-      </div>
+      )}
+      {holds.length == 0 && loans.length == 0 && (
+        <div className="font-[family-name:var(--font-rubik)] mb-5 mt-10">
+          You currently have no loans or holds
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/BookForm.tsx
+++ b/src/components/BookForm.tsx
@@ -109,7 +109,7 @@ const BookForm = (props: BookFormProps) => {
       setConfirmPopup({
         type: ConfirmPopupTypes.ISBN_ERROR,
         action: ConfirmPopupActions.NONE,
-        success: true,
+        success: false,
       });
     }
   }, [isbn, newBook.isbn, setConfirmPopup]);

--- a/src/components/common/tables/TableOverview.tsx
+++ b/src/components/common/tables/TableOverview.tsx
@@ -95,7 +95,7 @@ const TableOverview = (props: TableOverviewProps) => {
                   key={book.id}
                   className="flex flex-row w-full gap-1 text-base text-start font-normal text-[#202D74] "
                 >
-                  <p>{i}.</p>
+                  <p>{i + 1}.</p>
                   <Link
                     href={"/dashboard/books/" + book.id}
                     className="max-w-full"

--- a/src/components/common/tables/TableOverview.tsx
+++ b/src/components/common/tables/TableOverview.tsx
@@ -1,17 +1,20 @@
 "use client";
 import { getRequests } from "@/lib/api/requests";
+import { Book } from "@prisma/client";
+import Link from "next/link";
 
 import React, { useEffect, useState } from "react";
 import { DateRange } from "react-day-picker";
 import { Chart } from "react-google-charts";
 
 interface TableOverviewProps {
-  filterInfo: string; // TODO: change this prop as needed
+  borrowDuration: string;
+  topThree: Book[];
   requestCount: number;
   range: DateRange | undefined;
 }
 const TableOverview = (props: TableOverviewProps) => {
-  const { filterInfo, requestCount, range } = props;
+  const { borrowDuration, topThree, requestCount, range } = props;
   const [mapLevel, setMapLevel] = useState<Map<string, number> | null>(null);
   const [mapSkills, setMapSkills] = useState<Map<string, number> | null>(null);
 
@@ -64,9 +67,9 @@ const TableOverview = (props: TableOverviewProps) => {
   return (
     <div className="flex flex-col mt-6 mx-16 text-xl font-medium text-center gap-6">
       <div className="grid grid-cols-3 gap-6">
-        <div className="flex flex-col w-full aspect-[16/6] bg-[#F6FAFD] outline outline-2 outline-[#D4D4D4] text-black items-start justify-center p-6 rounded-[4] gap-2">
+        <div className="flex flex-col w-full aspect-[16/6] bg-[#F6FAFD] outline outline-2 outline-[#D4D4D4] text-black items-start justify-start p-6 rounded-[4] gap-2">
           <div>
-            <p className="text-xl font-semibold">Books Borrowed: </p>
+            <p className="text-xl font-semibold">No. of books borrowed </p>
           </div>
           <div>
             <p
@@ -79,32 +82,40 @@ const TableOverview = (props: TableOverviewProps) => {
                 : "loading..."}
             </p>
           </div>
+        </div>
+
+        <div className="flex flex-col w-full aspect-[16/6] bg-[#F6FAFD] outline outline-2 outline-[#D4D4D4] text-black items-start justify-start p-6 rounded-[4] gap-2">
           <div>
-            <p className="text-[#757575] font-normal">{filterInfo}</p>
+            <p className="text-xl font-semibold">Top 3 borrowed books </p>
+          </div>
+          <div className="w-full">
+            {topThree.map((book, i) => {
+              return (
+                <div
+                  key={book.id}
+                  className="flex flex-row w-full gap-1 text-base text-start font-normal text-[#202D74] "
+                >
+                  <p>{i}.</p>
+                  <Link
+                    href={"/dashboard/books/" + book.id}
+                    className="max-w-full"
+                  >
+                    <p className=" w-full text-base font-normal underline truncate ">
+                      {book.title}
+                    </p>
+                  </Link>
+                </div>
+              );
+            })}
           </div>
         </div>
 
-        <div className="flex flex-col w-full aspect-[16/6] bg-[#F6FAFD] outline outline-2 outline-[#D4D4D4] text-black items-start justify-center p-6 rounded-[4] gap-2">
+        <div className="flex flex-col w-full aspect-[16/6] bg-[#F6FAFD] outline outline-2 outline-[#D4D4D4] text-black items-start justify-start p-6 rounded-[4] gap-2">
           <div>
-            <p className="text-xl font-semibold">Books Added: </p>
+            <p className="text-xl font-semibold">Average borrow duration </p>
           </div>
           <div>
-            <p className="text-4xl font-medium">10</p>
-          </div>
-          <div>
-            <p className="text-[#757575] font-normal">{filterInfo}</p>
-          </div>
-        </div>
-
-        <div className="flex flex-col w-full aspect-[16/6] bg-[#F6FAFD] outline outline-2 outline-[#D4D4D4] text-black items-start justify-center p-6 rounded-[4] gap-2">
-          <div>
-            <p className="text-xl font-semibold">Books Removed: </p>
-          </div>
-          <div>
-            <p className="text-4xl font-medium">10</p>
-          </div>
-          <div>
-            <p className="text-[#757575] font-normal">{filterInfo}</p>
+            <p className="text-4xl font-medium">{borrowDuration}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Description

- on the shelf page there is now a "no loans or holds" message that displays instead of just blank headers
  - loans and holds headers will separately disappear if either of them lack members
- redesigned the 3 data trackers on the dashboard to match the new figma
  - includes avg request duration and top 3 requested books

## Issues
n/a

## Screenshots
![Screenshot 2025-04-26 at 2 17 56 AM](https://github.com/user-attachments/assets/1d29fbe9-b732-4029-97fe-02e3c85223f5)

## Test
- go to shelf and remove your holds to see the section headers dynamically disappear
- go to data dashboard and try messing with the date range to see the values change. Also try to verify that the information is correct by clicking through the top 3 links and seeing if they have requests

## Possible Downsides or 
- coded bad at 2am
- avg request duration prob rounds too much to really be that useful rn

